### PR TITLE
Add list command with deployments subcommand and related validations

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+enable_free_tier: true
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  suggested_labels: true
+  auto_review:
+    enabled: true
+    drafts: true
+chat:
+  auto_reply: true
+tools:
+    ast-grep:
+      rule_dirs: []
+      util_dirs: []
+      essential_rules: true
+      packages: []
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    languagetool:
+      enabled: true
+      enabled_rules: []
+      disabled_rules: []
+      enabled_categories: []
+      disabled_categories: []
+      enabled_only: false
+      level: default
+    hadolint:
+      enabled: true
+    golangci-lint:
+      enabled: true
+      config_file: ""
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -198,19 +198,19 @@ tasks:
   # DEVELOPMENT WORKFLOW
   ######################################################################
   dev:
-    desc: "Run development workflow (format, lint, test, build)"
+    desc: "Run development workflow (fmt, lint, test, build)"
     cmds:
-      - task: format
+      - task: fmt
       - task: lint
       - task: test
       - task: build
 
   ci:
-    desc: "Run CI workflow (format check, lint, test with coverage)"
+    desc: "Run CI workflow (fmt check, lint, test with coverage)"
     cmds:
-      - task: format
+      - task: fmt
       - task: lint
-      - task: test-coverage
+      - task: coverage
 
   ######################################################################
   # PODMAN COMMANDS

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -121,8 +121,16 @@ func validateNamespace(ns string) error {
 		return fmt.Errorf("namespace name too long (max 63 characters)")
 	}
 
-	// More detailed validation could be added here if needed
-	// For now, we trust that invalid names will be caught by the K8s API
+	// Basic DNS label validation
+	for i, r := range ns {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+			return fmt.Errorf("namespace name contains invalid character '%c' "+
+				"(must be lowercase alphanumeric with hyphens)", r)
+		}
+		if (i == 0 || i == len(ns)-1) && r == '-' {
+			return fmt.Errorf("namespace name cannot start or end with hyphen")
+		}
+	}
 
 	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,143 @@
+// Package cmd contains the CLI commands for the k8s-controller application.
+// This file implements the 'list' command which provides subcommands for listing Kubernetes resources.
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command.
+// It serves as a parent command for various resource listing operations.
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Kubernetes resources",
+	Long: `List various Kubernetes resources in your cluster.
+
+This command provides subcommands for listing different types of resources
+such as deployments, pods, services, etc.
+
+Examples:
+  kc list deployments
+  kc list deployments --namespace=default
+  kc list deployments --output=json`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		// If no subcommand is specified, show help
+		_ = cmd.Help()
+	},
+}
+
+// Shared flags for list operations
+var (
+	// namespace specifies the Kubernetes namespace to list resources from.
+	// If empty, resources from all namespaces will be listed.
+	namespace string
+
+	// outputFormat specifies the output format for the listed resources.
+	// Supported formats: table, json
+	outputFormat string
+)
+
+// listDeploymentsCmd represents the list deployments command.
+// It lists Kubernetes deployments with optional namespace filtering and output formatting.
+var listDeploymentsCmd = &cobra.Command{
+	Use:   "deployments",
+	Short: "List deployments",
+	Long: `List Kubernetes deployments in the specified namespace or all namespaces.
+
+This command connects to the Kubernetes API and retrieves deployment information.
+You can filter by namespace and choose different output formats.
+
+Examples:
+  kc list deployments                      # List all deployments
+  kc list deployments -n default          # List deployments in default namespace
+  kc list deployments -o json             # Output in JSON format
+  kc list deployments -n kube-system -o table  # Specific namespace, table format`,
+	Run: func(_ *cobra.Command, _ []string) {
+		log.Info().
+			Str("namespace", namespace).
+			Str("output", outputFormat).
+			Msg("Listing deployments")
+
+		if err := runListDeployments(); err != nil {
+			log.Error().Err(err).Msg("Failed to list deployments")
+			os.Exit(1)
+		}
+	},
+}
+
+// runListDeployments executes the deployment listing logic.
+// This function will be expanded in the next steps to include actual Kubernetes operations.
+func runListDeployments() error {
+	// TODO: Implement actual deployment listing using pkg/k8s
+	// For now, just validate the parameters and show what we would do
+
+	// Validate output format
+	if err := validateOutputFormat(outputFormat); err != nil {
+		return fmt.Errorf("invalid output format: %w", err)
+	}
+
+	// Validate namespace (if specified)
+	if err := validateNamespace(namespace); err != nil {
+		return fmt.Errorf("invalid namespace: %w", err)
+	}
+
+	// Placeholder implementation
+	if namespace == "" {
+		log.Info().Str("format", outputFormat).Msg("Would list deployments from all namespaces")
+	} else {
+		log.Info().
+			Str("namespace", namespace).
+			Str("format", outputFormat).
+			Msg("Would list deployments from specified namespace")
+	}
+
+	return nil
+}
+
+// validateOutputFormat ensures the output format is supported.
+func validateOutputFormat(format string) error {
+	switch format {
+	case "table", "json":
+		return nil
+	default:
+		return fmt.Errorf("unsupported format '%s', must be one of: table, json", format)
+	}
+}
+
+// validateNamespace performs basic validation on the namespace parameter.
+// Kubernetes namespace names must follow DNS label standards.
+func validateNamespace(ns string) error {
+	if ns == "" {
+		return nil // Empty namespace means "all namespaces"
+	}
+
+	// Basic namespace name validation
+	// Kubernetes names must be lowercase alphanumeric with hyphens
+	if len(ns) > 63 {
+		return fmt.Errorf("namespace name too long (max 63 characters)")
+	}
+
+	// More detailed validation could be added here if needed
+	// For now, we trust that invalid names will be caught by the K8s API
+
+	return nil
+}
+
+func init() {
+	// Register the list command with root
+	rootCmd.AddCommand(listCmd)
+
+	// Register the deployments subcommand with list
+	listCmd.AddCommand(listDeploymentsCmd)
+
+	// Add flags to the deployments command
+	listDeploymentsCmd.Flags().StringVarP(&namespace, "namespace", "n", "",
+		"Kubernetes namespace (default: all namespaces)")
+
+	listDeploymentsCmd.Flags().StringVarP(&outputFormat, "output", "o", "table",
+		"Output format (table|json)")
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,214 @@
+// Package cmd contains tests for the CLI commands.
+// This file tests the list command definition, flag configuration, and validation logic.
+package cmd
+
+import (
+	"testing"
+)
+
+// TestListCommandDefined verifies that the list command is properly defined
+// and configured with the expected properties.
+func TestListCommandDefined(t *testing.T) {
+	if listCmd == nil {
+		t.Fatal("listCmd should be defined")
+	}
+
+	if listCmd.Use != "list" {
+		t.Errorf("expected command use 'list', got %s", listCmd.Use)
+	}
+
+	// Verify that the deployments subcommand is registered
+	deploymentsCmdFound := false
+	for _, subCmd := range listCmd.Commands() {
+		if subCmd.Use == "deployments" {
+			deploymentsCmdFound = true
+			break
+		}
+	}
+
+	if !deploymentsCmdFound {
+		t.Error("deployments subcommand should be registered with list command")
+	}
+}
+
+// TestListDeploymentsCommandDefined verifies that the list deployments command
+// is properly defined and configured with the expected flags.
+func TestListDeploymentsCommandDefined(t *testing.T) {
+	if listDeploymentsCmd == nil {
+		t.Fatal("listDeploymentsCmd should be defined")
+	}
+
+	if listDeploymentsCmd.Use != "deployments" {
+		t.Errorf("expected command use 'deployments', got %s", listDeploymentsCmd.Use)
+	}
+
+	// Verify required flags are properly configured
+	tests := []struct {
+		flagName    string
+		shorthand   string
+		shouldExist bool
+	}{
+		{"namespace", "n", true},
+		{"output", "o", true},
+	}
+
+	for _, tt := range tests {
+		t.Run("flag_"+tt.flagName, func(t *testing.T) {
+			flag := listDeploymentsCmd.Flags().Lookup(tt.flagName)
+			if tt.shouldExist && flag == nil {
+				t.Errorf("expected '%s' flag to be defined", tt.flagName)
+			}
+			if !tt.shouldExist && flag != nil {
+				t.Errorf("expected '%s' flag not to be defined", tt.flagName)
+			}
+
+			// Check shorthand if flag exists
+			if tt.shouldExist && flag != nil && flag.Shorthand != tt.shorthand {
+				t.Errorf("expected '%s' flag shorthand to be '%s', got '%s'",
+					tt.flagName, tt.shorthand, flag.Shorthand)
+			}
+		})
+	}
+}
+
+// TestListDeploymentsFlagParsing verifies that the list deployments command
+// correctly parses flag values.
+func TestListDeploymentsFlagParsing(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		expectedNamespace string
+		expectedOutput    string
+		shouldErr         bool
+	}{
+		{
+			name:              "default values",
+			args:              []string{},
+			expectedNamespace: "",
+			expectedOutput:    "table",
+			shouldErr:         false,
+		},
+		{
+			name:              "namespace flag",
+			args:              []string{"--namespace=default"},
+			expectedNamespace: "default",
+			expectedOutput:    "table",
+			shouldErr:         false,
+		},
+		{
+			name:              "namespace short flag",
+			args:              []string{"-n", "kube-system"},
+			expectedNamespace: "kube-system",
+			expectedOutput:    "table",
+			shouldErr:         false,
+		},
+		{
+			name:              "output flag",
+			args:              []string{"--output=json"},
+			expectedNamespace: "",
+			expectedOutput:    "json",
+			shouldErr:         false,
+		},
+		{
+			name:              "output short flag",
+			args:              []string{"-o", "json"},
+			expectedNamespace: "",
+			expectedOutput:    "json",
+			shouldErr:         false,
+		},
+		{
+			name:              "both flags",
+			args:              []string{"-n", "default", "-o", "json"},
+			expectedNamespace: "default",
+			expectedOutput:    "json",
+			shouldErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset variables
+			namespace = ""
+			outputFormat = "table"
+
+			// Parse flags
+			err := listDeploymentsCmd.ParseFlags(tt.args)
+			if tt.shouldErr && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.shouldErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Check values if no error expected
+			if !tt.shouldErr {
+				if namespace != tt.expectedNamespace {
+					t.Errorf("expected namespace %s, got %s", tt.expectedNamespace, namespace)
+				}
+				if outputFormat != tt.expectedOutput {
+					t.Errorf("expected output %s, got %s", tt.expectedOutput, outputFormat)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateOutputFormat tests the output format validation function.
+func TestValidateOutputFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		shouldErr bool
+	}{
+		{"valid table format", "table", false},
+		{"valid json format", "json", false},
+		{"invalid format", "yaml", true},
+		{"invalid format xml", "xml", true},
+		{"empty format", "", true},
+		{"case sensitive", "Table", true}, // Should be lowercase
+		{"case sensitive json", "JSON", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOutputFormat(tt.format)
+			if tt.shouldErr && err == nil {
+				t.Errorf("validateOutputFormat(%s) should return error, got nil", tt.format)
+			}
+			if !tt.shouldErr && err != nil {
+				t.Errorf("validateOutputFormat(%s) should not return error, got: %v", tt.format, err)
+			}
+		})
+	}
+}
+
+// TestValidateNamespace tests the namespace validation function.
+func TestValidateNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		shouldErr bool
+	}{
+		{"empty namespace", "", false}, // Empty means all namespaces
+		{"valid namespace", "default", false},
+		{"valid namespace with hyphen", "kube-system", false},
+		{"valid namespace with numbers", "test123", false},
+		{
+			"too long namespace",
+			"this-is-a-very-long-namespace-name-that-exceeds-the-maximum-length-allowed-by-kubernetes",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNamespace(tt.namespace)
+			if tt.shouldErr && err == nil {
+				t.Errorf("validateNamespace(%s) should return error, got nil", tt.namespace)
+			}
+			if !tt.shouldErr && err != nil {
+				t.Errorf("validateNamespace(%s) should not return error, got: %v", tt.namespace, err)
+			}
+		})
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -74,15 +74,32 @@ func TestListDeploymentsCommandDefined(t *testing.T) {
 // TestListDeploymentsFlagParsing verifies that the list deployments command
 // correctly parses flag values.
 func TestListDeploymentsFlagParsing(t *testing.T) {
+	tests := createFlagParsingTestCases()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runFlagParsingTest(t, tt.args, tt.expectedNamespace, tt.expectedOutput, tt.shouldErr)
+		})
+	}
+}
+
+// createFlagParsingTestCases creates test cases for flag parsing to reduce function length.
+func createFlagParsingTestCases() []struct {
+	name              string
+	args              []string
+	expectedNamespace string
+	expectedOutput    string
+	shouldErr         bool
+} {
 	// Define test constants to avoid duplication
 	const (
-		defaultNS    string = "default"
-		kubeSystemNS string = "kube-system"
-		tableFormat  string = "table"
-		jsonFormat   string = "json"
+		defaultNS    = "default"
+		kubeSystemNS = "kube-system"
+		tableFormat  = "table"
+		jsonFormat   = "json"
 	)
 
-	tests := []struct {
+	return []struct {
 		name              string
 		args              []string
 		expectedNamespace string
@@ -131,12 +148,6 @@ func TestListDeploymentsFlagParsing(t *testing.T) {
 			expectedOutput:    jsonFormat,
 			shouldErr:         false,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runFlagParsingTest(t, tt.args, tt.expectedNamespace, tt.expectedOutput, tt.shouldErr)
-		})
 	}
 }
 
@@ -199,7 +210,7 @@ func TestValidateOutputFormat(t *testing.T) {
 
 // TestValidateNamespace tests the namespace validation function.
 func TestValidateNamespace(t *testing.T) {
-	const kubeSystemNS string = "kube-system" // Define constant to avoid duplication
+	const kubeSystemNS = "kube-system" // Define constant to avoid duplication
 
 	tests := []struct {
 		name      string

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -221,11 +221,19 @@ func TestValidateNamespace(t *testing.T) {
 		{"valid namespace", "default", false},
 		{"valid namespace with hyphen", kubeSystemNS, false},
 		{"valid namespace with numbers", "test123", false},
+		{"valid namespace with mixed", "app-v2", false},
 		{
 			"too long namespace",
 			"this-is-a-very-long-namespace-name-that-exceeds-the-maximum-length-allowed-by-kubernetes",
 			true,
 		},
+		{"uppercase characters", "MyNamespace", true},
+		{"contains underscore", "my_namespace", true},
+		{"contains dot", "my.namespace", true},
+		{"starts with hyphen", "-myns", true},
+		{"ends with hyphen", "myns-", true},
+		{"contains space", "my namespace", true},
+		{"special characters", "my@namespace", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new CLI command to list Kubernetes resources, with a subcommand for listing deployments. Supports namespace filtering and output formatting options (table or JSON).

* **Bug Fixes**
  * Improved validation and error handling for command parameters.

* **Tests**
  * Added comprehensive tests for the new CLI listing commands, flag parsing, and input validation.

* **Chores**
  * Updated task names and descriptions in development and CI workflows for consistency.
  * Added configuration for CodeRabbit AI integration, enabling various analysis and linting tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->