### PR TITLE
fix(devcontainer): make the devcontainer usable in Codespaces

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,35 +13,35 @@ reviews:
   auto_review:
     enabled: true
     drafts: true
+  tools:
+      ast-grep:
+        rule_dirs: []
+        util_dirs: []
+        essential_rules: true
+        packages: []
+      shellcheck:
+        enabled: true
+      markdownlint:
+        enabled: true
+      github-checks:
+        enabled: true
+        timeout_ms: 90000
+      languagetool:
+        enabled: true
+        enabled_rules: []
+        disabled_rules: []
+        enabled_categories: []
+        disabled_categories: []
+        enabled_only: false
+        level: default
+      hadolint:
+        enabled: true
+      golangci-lint:
+        enabled: true
+        config_file: ""
+      yamllint:
+        enabled: true
+      gitleaks:
+        enabled: true
 chat:
   auto_reply: true
-tools:
-    ast-grep:
-      rule_dirs: []
-      util_dirs: []
-      essential_rules: true
-      packages: []
-    shellcheck:
-      enabled: true
-    markdownlint:
-      enabled: true
-    github-checks:
-      enabled: true
-      timeout_ms: 90000
-    languagetool:
-      enabled: true
-      enabled_rules: []
-      disabled_rules: []
-      enabled_categories: []
-      disabled_categories: []
-      enabled_only: false
-      level: default
-    hadolint:
-      enabled: true
-    golangci-lint:
-      enabled: true
-      config_file: ""
-    yamllint:
-      enabled: true
-    gitleaks:
-      enabled: true

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -44,8 +44,9 @@ Check or stop services:
 
 - `iptables` must be installed and usable.
 - The pause image must be pulled with a platform hint:
-  `sudo ctr -n k8s.io images pull --platform linux/amd64 registry.k8s.io/pause:3.10`
+  `sudo ctr -n k8s.io images pull --platform linux/amd64 registry.k8s.io/pause:3.10` (use `linux/arm64` on ARM)
 - Codespaces/devcontainer should run with `--cgroupns=host` so cgroup v2 can be delegated.
+- Containerd should use local image pull to avoid platform unpack errors.
 
 ## Common paths
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -11,18 +11,19 @@ This devcontainer provisions a local, single-node Kubernetes control plane for c
 
 ## Getting started
 
-Run the setup once to install components and generate certs:
+Everything goes through [Task](https://taskfile.dev), which is the single
+source of truth for this repository. Run the setup once to install the
+components and generate the certificates:
 
 ```bash
 task collections
-cd ansible/
-ansible-playbook devcontainer.yml
+task devcontainer
 ```
 
 Start the cluster:
 
 ```bash
-ansible-playbook devcontainer-run.yml
+task devcontainer-run
 ```
 
 Verify:
@@ -40,13 +41,39 @@ Check or stop services:
 ~/k8s-stop.sh
 ```
 
-## Requirements for pods to start
+## Partial runs
 
-- `iptables` must be installed and usable.
-- The pause image must be pulled with a platform hint:
-  `sudo ctr -n k8s.io images pull --platform linux/amd64 registry.k8s.io/pause:3.10` (use `linux/arm64` on ARM)
-- Codespaces/devcontainer should run with `--cgroupns=host` so cgroup v2 can be delegated.
-- Containerd should use local image pull to avoid platform unpack errors.
+Both playbooks are tagged, so you can re-run only a part of them by
+passing extra arguments through Task:
+
+```bash
+task devcontainer-run -- -t preflight
+task devcontainer-run -- -t control-plane
+task devcontainer-run -- -t verify
+```
+
+Available tags:
+
+- `devcontainer.yml`: `install`, `certs`, `config`, `verify`, `summary`
+- `devcontainer-run.yml`: `preflight`, `control-plane` (alias `start`),
+  `verify` (alias `health`), `status` (alias `report`), and `debug`,
+  which is also tagged `never` and has to be requested explicitly.
+
+## What makes pods runnable
+
+These used to be manual steps. They are handled automatically now, so no
+extra commands are needed:
+
+- `iptables` is installed by `task devcontainer`
+  ("Install | Ensure iptables is available").
+- The pause image is pre-pulled with a platform hint by
+  `task devcontainer-run` ("Start | Pre-pull pause image for kubelet"),
+  using the architecture detected in `ansible/group_vars/all.yml`.
+- `--cgroupns=host` is already set in `runArgs` in
+  `.devcontainer/devcontainer.json`, so cgroup v2 can be delegated.
+- `use_local_image_pull = true` is set in the generated containerd config
+  (`ansible/templates/containerd-config.toml.j2`) to avoid platform
+  unpack errors.
 
 ## Common paths
 
@@ -68,7 +95,7 @@ Restart control plane and kubelet:
 
 ```bash
 ~/k8s-stop.sh
-ansible-playbook devcontainer-run.yml -t control-plane,worker
+task devcontainer-run -- -t control-plane
 ```
 
 View logs:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,10 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24"
+      "version": "1.25"
     },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-      "version": "1.30.0",
+      "version": "1.31.0",
       "helm": "latest",
       "minikube": "none"
     },
@@ -39,6 +39,7 @@
   // Enable privileged mode for Kubernetes components
   "runArgs": [
     "--privileged",
+    "--cgroupns=host",
     "--security-opt",
     "seccomp=unconfined",
     "--cap-add=SYS_ADMIN",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,8 +20,7 @@
     "ghcr.io/devcontainers-extra/features/go-task:1": {},
     "ghcr.io/devcontainers-extra/features/wget-apt-get:1": {},
     "ghcr.io/jungaretti/features/vim:1": {},
-    "ghcr.io/devcontainers-extra/features/starship:1": {},
-    "ghcr.io/devcontainers-contrib/features/zsh-plugins:0": {}
+    "ghcr.io/devcontainers-extra/features/starship:1": {}
   },
   "containerEnv": {
     "FORCE_COLOR": "1"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "k8s-controller",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
       "version": "1.25"
@@ -18,7 +18,6 @@
     },
     "ghcr.io/rio/features/k9s:1": {},
     "ghcr.io/devcontainers-extra/features/go-task:1": {},
-    "ghcr.io/devcontainers-extra/features/ansible:2": {},
     "ghcr.io/devcontainers-extra/features/wget-apt-get:1": {},
     "ghcr.io/jungaretti/features/vim:1": {},
     "ghcr.io/devcontainers-extra/features/starship:1": {},
@@ -28,7 +27,7 @@
     "FORCE_COLOR": "1"
   },
   "remoteUser": "vscode",
-  "postCreateCommand": "task collections && task setup",
+  "postCreateCommand": "pipx install ansible-core && task collections && task setup",
   "hostRequirements": {
     "cpus": 4,
     "memory": "4gb"

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Open the repository in VS Code (*Reopen in Container*) or in
 [GitHub Codespaces](https://github.com/features/codespaces), then:
 
 ```bash
-# Install etcd, kube-apiserver, kubelet, containerd, runc and CNI plugins
+# Install the binaries, generate the PKI and write the config files
 task devcontainer
 
-# Generate PKI, render the unit files and start every component
+# Start containerd, etcd, the control plane components and kubelet
 task devcontainer-run
 
 # Use the cluster

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This project follows [the step-by-step tutorial](https://github.com/den-vasyliev
 - **Podman** - [Installation guide](https://podman.io/getting-started/installation)
 - **Docker** (optional) - Alternative to Podman
 
+Nothing installed locally? Use
+[Dev Container / Codespaces](#dev-container--codespaces) instead.
+
 ### One-Command Setup
 
 Get a complete Kubernetes development environment running in seconds:
@@ -50,6 +53,34 @@ This automated setup creates:
 - Kubelet with containerd runtime
 - CNI networking with bridge plugin
 - PKI infrastructure with auto-generated certificates
+
+### Dev Container / Codespaces
+
+The same cluster runs inside a Dev Container, so no Podman machine is needed.
+Open the repository in VS Code (*Reopen in Container*) or in
+[GitHub Codespaces](https://github.com/features/codespaces), then:
+
+```bash
+# Install etcd, kube-apiserver, kubelet, containerd, runc and CNI plugins
+task devcontainer
+
+# Generate PKI, render the unit files and start every component
+task devcontainer-run
+
+# Use the cluster
+kubectl get nodes
+kubectl get all -A
+```
+
+Two helpers are placed in the container home directory:
+
+```bash
+~/k8s-status.sh   # state of every component
+~/k8s-stop.sh     # stop the control plane
+```
+
+Both playbooks read the same `ansible/group_vars/all.yml` as `provision.yml`,
+so versions, CIDRs and paths match the Podman/Docker environment.
 
 ## Development Environment
 
@@ -79,6 +110,10 @@ task ssh          # SSH into the machine
 task provision    # Run Ansible provisioning
 task reboot       # Restart the machine
 task rm           # Remove the machine
+
+# Dev Container / Codespaces
+task devcontainer     # Install K8s components into the devcontainer
+task devcontainer-run # Start the control plane inside the devcontainer
 ```
 
 ## Progress
@@ -134,17 +169,21 @@ C4Container
 ## Project Structure
 
 ```bash
-├── ansible/              # Kubernetes cluster automation
-│   ├── README.md         # Detailed Ansible documentation
-│   ├── init.yml          # Initial system setup
-│   ├── provision.yml     # Main K8s provisioning
-│   └── templates/        # Service and config templates
-├── cmd/                  # CLI application code
-├── notebooks/            # Go learning notebooks
-├── scripts/              # Setup and utility scripts
-├── Taskfile.yaml        # Task automation
-├── Dockerfile           # Container image definition
-└── README.md            # This file
+├── .devcontainer/            # Dev Container / Codespaces definition
+├── ansible/                  # Kubernetes cluster automation
+│   ├── README.md             # Detailed Ansible documentation
+│   ├── group_vars/           # Shared vars: versions, CIDRs, paths
+│   ├── init.yml              # Initial system setup
+│   ├── provision.yml         # Main K8s provisioning (Podman VM)
+│   ├── devcontainer.yml      # Install K8s into a devcontainer
+│   ├── devcontainer-run.yml  # Run K8s inside a devcontainer
+│   └── templates/            # Service and config templates
+├── cmd/                      # CLI application code
+├── notebooks/                # Go learning notebooks
+├── scripts/                  # Setup and utility scripts
+├── Taskfile.yaml             # Task automation
+├── Dockerfile                # Container image definition
+└── README.md                 # This file
 ```
 
 ## 📚 Documentation

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -273,3 +273,32 @@ tasks:
         task ssh -- 'cd /srv/app && go-task provision' # To run from the host machine
     cmds:
       - ansible-playbook provision.yml {{.CLI_ARGS}}
+
+  ####################################################################
+  # DEVCONTAINER
+  ####################################################################
+  devcontainer:
+    dir: "{{.USER_WORKING_DIR}}/ansible"
+    desc: "Install K8s components into the devcontainer"
+    summary: |
+      Installs etcd, kube-apiserver, kubelet, containerd, runc and the CNI
+      plugins straight into the running devcontainer. No Podman VM needed.
+
+      Example:
+        task collections
+        task devcontainer
+    cmds:
+      - ansible-playbook devcontainer.yml {{.CLI_ARGS}}
+
+  devcontainer-run:
+    dir: "{{.USER_WORKING_DIR}}/ansible"
+    desc: "Start the control plane inside the devcontainer"
+    summary: |
+      Starts containerd, etcd and the control plane installed by
+      `task devcontainer`, then waits until the node reports Ready.
+
+      Example:
+        task devcontainer-run
+        kubectl get nodes
+    cmds:
+      - ansible-playbook devcontainer-run.yml {{.CLI_ARGS}}

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -87,10 +87,10 @@ kubectl get all -A
 Inside a Dev Container there is no Podman machine, so the playbooks run locally:
 
 ```bash
-# Install etcd, kube-apiserver, kubelet, containerd, runc and CNI plugins
+# Install the binaries, generate the PKI and write the config files
 task devcontainer
 
-# Generate PKI, render the unit files and start every component
+# Start containerd, etcd, the control plane components and kubelet
 task devcontainer-run
 ```
 
@@ -122,8 +122,9 @@ The main provisioning playbook supports these tags for selective execution:
 
 The devcontainer playbooks have their own tags: `install`, `certs`,
 `config`, `verify` and `summary` for `devcontainer.yml`; `preflight`,
-`start`, `control-plane`, `health`, `status` and `report` for
-`devcontainer-run.yml`.
+`control-plane`, `start`, `verify`, `health`, `status`, `report` and
+`debug` for `devcontainer-run.yml`. The debug block is also tagged
+`never`, so it only runs when you ask for it with `-t debug`.
 
 ## Configuration
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -10,24 +10,36 @@ The Ansible setup provides automated installation and configuration of:
 - **Complete Kubernetes cluster** with all control plane components
 - **Container runtime** (containerd) and networking (CNI)
 - **PKI infrastructure** with automatic certificate generation
+- **Dev Container support** so the same cluster runs inside Codespaces
 
 ## Structure
 
 ```txt
 ansible/
-├── ansible.cfg          # Ansible configuration
-├── inventory.yml        # Local inventory configuration
-├── requirements.yml     # Required Ansible collections
-├── init.yml            # Initial system setup playbook
-├── provision.yml       # Main Kubernetes provisioning playbook
-└── templates/          # Jinja2 templates for configs and services
+├── ansible.cfg           # Ansible configuration
+├── inventory.yml         # Local inventory configuration
+├── requirements.yml      # Required Ansible collections
+├── group_vars/all.yml    # Shared vars: versions, CIDRs, paths
+├── init.yml              # Initial system setup playbook
+├── provision.yml         # Podman machine provisioning
+├── devcontainer.yml      # Devcontainer installation
+├── devcontainer-run.yml  # Devcontainer control plane start
+└── templates/            # Jinja2 templates for configs and services
 ```
 
 ## Prerequisites
 
+Podman machine path:
+
 - Podman machine running Fedora CoreOS
 - Ansible installed on the host system
 - Required Ansible collections (installed automatically)
+
+Dev Container path:
+
+- Repository opened in the Dev Container
+  (`.devcontainer/devcontainer.json`)
+- `ansible-core` and the collections are installed by `postCreateCommand`
 
 ## Quick Start
 
@@ -70,6 +82,32 @@ kubectl get nodes
 kubectl get all -A
 ```
 
+### 4. Dev Container / Codespaces
+
+Inside a Dev Container there is no Podman machine, so the playbooks run locally:
+
+```bash
+# Install etcd, kube-apiserver, kubelet, containerd, runc and CNI plugins
+task devcontainer
+
+# Generate PKI, render the unit files and start every component
+task devcontainer-run
+```
+
+Extra Ansible arguments are passed through, so tags work the same way:
+
+```bash
+task devcontainer -- '-t install'
+task devcontainer-run -- '-t status'
+```
+
+Helper scripts are installed into the container home directory:
+
+```bash
+~/k8s-status.sh   # state of every component
+~/k8s-stop.sh     # stop the control plane
+```
+
 ## Available Tags
 
 The main provisioning playbook supports these tags for selective execution:
@@ -82,16 +120,28 @@ The main provisioning playbook supports these tags for selective execution:
 - `kubelet` - Configure and start kubelet with containerd
 - `leftovers` - Final verification and cleanup tasks
 
+The devcontainer playbooks have their own tags: `install`, `certs`,
+`config`, `verify` and `summary` for `devcontainer.yml`; `preflight`,
+`start`, `control-plane`, `health`, `status` and `report` for
+`devcontainer-run.yml`.
+
 ## Configuration
 
-Key variables are defined in `provision.yml`:
+Shared variables live in `group_vars/all.yml` and are read by every playbook:
 
 ```yaml
 k8s_version: "1.30.0"
 containerd_version: "2.1.2"
-pod_network_cidr: "10.244.0.0/16"
-service_cidr: "10.96.0.0/12"
+runc_version: "1.2.6"
+cni_version: "1.6.2"
+cluster_cidr: "10.216.0.0/16"
+service_cidr: "10.216.224.0/24"
+pod_network_cidr: "10.144.0.0/16"
 ```
+
+`etcd`, `kube-apiserver` and `kubectl` come from the `controller-tools`
+`envtest` releases; containerd, runc and the CNI plugins come from their own
+upstream releases.
 
 ## Logging
 

--- a/ansible/devcontainer-run.yml
+++ b/ansible/devcontainer-run.yml
@@ -5,7 +5,7 @@
   become: true
   vars:
     # --- User Configuration ---
-    devcontainer_user: "{{ ansible_env.SUDO_USER | default(ansible_env.USER) | default('vscode') }}"
+    devcontainer_user: "{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['env']['USER'] | default('vscode')) }}"
 
   tasks:
     - name: "Pre-flight checks and setup"
@@ -75,7 +75,7 @@
         ################################################################
         - name: "Start | Start containerd"
           environment:
-            PATH: "{{ ansible_env.PATH }}:/opt/cni/bin:/usr/sbin"
+            PATH: "{{ ansible_facts['env']['PATH'] | default('') }}:/opt/cni/bin:/usr/sbin"
           ansible.builtin.shell: |
             nohup {{ bin_path }}/containerd \
               -c /etc/containerd/config.toml \
@@ -93,6 +93,12 @@
           until: containerd_socket.stat.exists
           retries: 10
           delay: 2
+
+        - name: "Start | Pre-pull pause image for kubelet"
+          ansible.builtin.shell: |
+            {{ bin_path }}/ctr -n k8s.io images pull --platform linux/amd64 registry.k8s.io/pause:3.10
+          register: pause_pull
+          changed_when: "'resolved' in pause_pull.stdout or 'done' in pause_pull.stdout or pause_pull.rc == 0"
 
         - name: "Start | Test containerd"
           ansible.builtin.shell: |
@@ -190,7 +196,7 @@
         ################################################################
         - name: "Start | Start kube-controller-manager"
           environment:
-            PATH: "{{ ansible_env.PATH }}:/opt/cni/bin:/usr/sbin"
+            PATH: "{{ ansible_facts['env']['PATH'] | default('') }}:/opt/cni/bin:/usr/sbin"
           ansible.builtin.shell: |
             nohup {{ bin_path }}/kube-controller-manager \
               --kubeconfig={{ config_path }}/kube-controller-manager.kubeconfig \
@@ -268,7 +274,7 @@
         ################################################################
         - name: "Start | Start kubelet"
           environment:
-            PATH: "{{ ansible_env.PATH }}:/opt/cni/bin:/usr/sbin"
+            PATH: "{{ ansible_facts['env']['PATH'] | default('') }}:/opt/cni/bin:/usr/sbin"
           ansible.builtin.shell: |
             nohup {{ bin_path }}/kubelet \
               --kubeconfig={{ kubelet_data_path }}/kubeconfig \

--- a/ansible/devcontainer-run.yml
+++ b/ansible/devcontainer-run.yml
@@ -96,7 +96,7 @@
 
         - name: "Start | Pre-pull pause image for kubelet"
           ansible.builtin.shell: |
-            {{ bin_path }}/ctr -n k8s.io images pull --platform linux/amd64 registry.k8s.io/pause:3.10
+            {{ bin_path }}/ctr -n k8s.io images pull --platform linux/{{ arch }} registry.k8s.io/pause:3.10
           register: pause_pull
           changed_when: "'resolved' in pause_pull.stdout or 'done' in pause_pull.stdout or pause_pull.rc == 0"
 

--- a/ansible/devcontainer-run.yml
+++ b/ansible/devcontainer-run.yml
@@ -94,18 +94,29 @@
           retries: 10
           delay: 2
 
-        - name: "Start | Pre-pull pause image for kubelet"
-          ansible.builtin.shell: |
-            {{ bin_path }}/ctr -n k8s.io images pull --platform linux/{{ arch }} registry.k8s.io/pause:3.10
-          register: pause_pull
-          changed_when: "'resolved' in pause_pull.stdout or 'done' in pause_pull.stdout or pause_pull.rc == 0"
-
         - name: "Start | Test containerd"
           ansible.builtin.shell: |
             {{ bin_path }}/ctr version
           register: containerd_test
-          retries: 3
+          until: containerd_test.rc == 0
+          retries: 10
           delay: 2
+          changed_when: false
+
+        - name: "Start | List images in the k8s.io namespace"
+          ansible.builtin.shell: |
+            {{ bin_path }}/ctr -n k8s.io images ls -q
+          register: pause_images
+          changed_when: false
+
+        - name: "Start | Pre-pull pause image for kubelet"
+          ansible.builtin.shell: |
+            {{ bin_path }}/ctr -n k8s.io images pull --platform linux/{{ arch }} registry.k8s.io/pause:3.10
+          register: pause_pull
+          until: pause_pull.rc == 0
+          retries: 5
+          delay: 3
+          when: "'registry.k8s.io/pause:3.10' not in pause_images.stdout_lines"
 
         ################################################################
         # ┌─┐┌┬┐┌─┐┌┬┐

--- a/ansible/devcontainer.yml
+++ b/ansible/devcontainer.yml
@@ -8,8 +8,11 @@
     wip_dir: "/tmp/k8s_wip"
 
     # --- User Configuration ---
-    devcontainer_user: "{{ ansible_env.SUDO_USER | default(ansible_env.USER) | default('vscode') }}"
+    devcontainer_user: "{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['env']['USER'] | default('vscode')) }}"
     user_home: "/home/{{ devcontainer_user }}"
+    download_timeout: 120
+    download_retries: 3
+    download_delay: 5
 
   tasks:
     - name: "Install K8s binaries"
@@ -56,10 +59,15 @@
             url: "https://dl.k8s.io/v{{ k8s_version }}/bin/linux/{{ arch }}/{{ item }}"
             dest: "{{ bin_path }}/{{ item }}"
             mode: "0755"
+            timeout: "{{ download_timeout }}"
           loop:
             - kubelet
             - kube-controller-manager
             - kube-scheduler
+          register: k8s_component_downloads
+          retries: "{{ download_retries }}"
+          delay: "{{ download_delay }}"
+          until: k8s_component_downloads is succeeded
 
         - name: "Install | Download and unpack Containerd"
           ansible.builtin.unarchive:
@@ -91,6 +99,12 @@
             dest: "{{ cni_path }}"
             remote_src: true
             creates: "{{ cni_path }}/bridge"
+
+        - name: "Install | Ensure iptables is available"
+          ansible.builtin.apt:
+            name: iptables
+            state: present
+            update_cache: true
 
     - name: "Generate certificates and tokens"
       tags: ["certs"]

--- a/ansible/devcontainer.yml
+++ b/ansible/devcontainer.yml
@@ -38,14 +38,14 @@
 
         - name: "Install | Download and unpack Kubebuilder tools (etcd, kube-apiserver)"
           ansible.builtin.unarchive:
-            src: "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-{{ k8s_version }}-linux-{{ arch }}.tar.gz"
+            src: "https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-v{{ k8s_version }}/envtest-v{{ k8s_version }}-linux-{{ arch }}.tar.gz"
             dest: "{{ wip_dir }}"
             remote_src: true
-            creates: "{{ wip_dir }}/kubebuilder/bin/kube-apiserver"
+            creates: "{{ wip_dir }}/controller-tools/envtest/kube-apiserver"
 
         - name: "Install | Move Kubebuilder binaries to {{ bin_path }}"
           ansible.builtin.copy:
-            src: "{{ wip_dir }}/kubebuilder/bin/{{ item }}"
+            src: "{{ wip_dir }}/controller-tools/envtest/{{ item }}"
             dest: "{{ bin_path }}/{{ item }}"
             mode: "0755"
             remote_src: true

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -6,7 +6,7 @@ runc_version:         "1.2.6"
 cni_version:          "1.6.2"
 
 # --- System Configuration ---
-arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+arch: "{{ 'arm64' if ansible_facts['architecture'] == 'aarch64' else 'amd64' }}"
 cluster_cidr:         "10.216.0.0/16"   # 216 = 6^3 (Cube)
 service_cidr:         "10.216.224.0/24" # 224 = 4^2+8^2+12^2 (sum of 3 squares)
 pod_network_cidr:     "10.144.0.0/16"   # fibonnacci number

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -34,14 +34,14 @@
 
         - name: "Install | Download and unpack Kubebuilder tools (etcd, kube-apiserver)"
           ansible.builtin.unarchive:
-            src: "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-{{ k8s_version }}-linux-{{ arch }}.tar.gz"
+            src: "https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-v{{ k8s_version }}/envtest-v{{ k8s_version }}-linux-{{ arch }}.tar.gz"
             dest: "{{ wip_dir }}"
             remote_src: true
-            creates: "{{ wip_dir }}/kubebuilder/bin/kube-apiserver"
+            creates: "{{ wip_dir }}/controller-tools/envtest/kube-apiserver"
 
         - name: "Install | Move Kubebuilder binaries to {{ bin_path }}"
           ansible.builtin.copy:
-            src: "{{ wip_dir }}/kubebuilder/bin/{{ item }}"
+            src: "{{ wip_dir }}/controller-tools/envtest/{{ item }}"
             dest: "{{ bin_path }}/{{ item }}"
             mode: "0755"
             remote_src: true

--- a/ansible/templates/containerd-config.toml.j2
+++ b/ansible/templates/containerd-config.toml.j2
@@ -13,9 +13,10 @@ version = 3
 [plugins.'io.containerd.cri.v1.images']
   snapshotter = "native"
   disable_snapshot_annotations = true
+  use_local_image_pull = true
 
 [plugins.'io.containerd.cri.v1.runtime'.cni]
-  bin_dir = "/opt/cni/bin"
+  bin_dirs = ["/opt/cni/bin"]
   conf_dir = "/etc/cni/net.d"
 
 [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]


### PR DESCRIPTION
## [fix] Make the devcontainer usable in Codespaces

The devcontainer could not be built, and even after a manual build the setup
playbook failed while downloading the envtest binaries. This branch fixes both
and wires the devcontainer into the Taskfile.

### Changes

- Use the `python:3.12` base image and install Ansible with `pipx`. The
  `ansible` dev container feature no longer resolves, so it is gone.
- Take the envtest binaries from the `controller-tools` releases and fix the
  unpack paths to match the archive layout, in both `ansible/devcontainer.yml`
  and `ansible/provision.yml`.
- Add `task devcontainer` and `task devcontainer-run`, so the devcontainer is
  driven through Task like everything else.
- Update `README.md`, `ansible/README.md` and `.devcontainer/README.md` to
  describe the devcontainer workflow and to use the task names instead of raw
  `ansible-playbook` calls.
- Earlier commits on this branch make pods runnable in Codespaces:
  `--cgroupns=host`, iptables, pause image pre-pull and local image pull.

### How it was tested

In a fresh Codespace on this branch:

- `task devcontainer` and `task devcontainer-run` finish with `failed=0`, and
  the node reports `Ready` (v1.30.0, containerd 2.1.2).
- Two nginx pods reach `Running` with pod-network addresses.
- `connection` and `list deployments` both work against the cluster.
- `task devcontainer-run -- -t preflight`, `-t verify` and `-t status` pass.

No Go code changed, so the Go Tests workflow does not run on this branch.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/searge/k8s-controller/blob/main/docs/CONTRIBUTING.md) for this repository.
- [x] I have followed the correct format for my commit messages.
- [x] I have updated the documentation to reflect my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Dev Container and Codespaces support for setting up and running a local Kubernetes control plane.
  - Added tasks to install Kubernetes components and start the control plane automatically.
  - Added status and stop helpers plus support for partial automation runs and configuration tags.

- **Bug Fixes**
  - Improved startup reliability with automatic prerequisite image preparation.
  - Added download retries and timeouts for more resilient setup.
  - Updated architecture handling and Kubernetes tool installation sources.

- **Documentation**
  - Expanded setup, verification, troubleshooting, workflow, and project structure guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->