### PR TITLE
chore(github): simplify code owners and tighten Dependabot auto-merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
+# Single maintainer: @searge owns every path in this repository.
 * @searge
-
-# Core application directories
-/cmd/ @gidra39 @oleksiihead
-/pkg/ @gidra39 @oleksiihead

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,7 +2,13 @@ pull_request_rules:
   - name: automatic merge for Dependabot pull requests
     conditions:
       - author=dependabot[bot]
-
+      - base=main
+      - -draft
+      - -conflict
+      # Static analysis must be green. These two checks run on every pull
+      # request, including dependency bumps.
+      - check-success=Codacy Static Code Analysis
+      - check-success=SonarCloud Code Analysis
     actions:
       merge:
         method: merge


### PR DESCRIPTION
## Summary

The project has a single maintainer now, so the review setup can be simpler.

- `.github/CODEOWNERS`: `@searge` owns every path. The extra owners for `/cmd/` and `/pkg/` are removed.
- `.github/mergify.yml`: the Dependabot rule now also requires the pull request to target `main`, to be ready for review, to have no conflicts, and to pass Codacy and SonarCloud.

## Why

The old Mergify rule matched only on the author, so a dependency bump could be merged even with red checks. Since the branch ruleset no longer requires an approval, the checks are the only safety net left.

## Known gap

`Go Tests` does not run on dependency bumps, because the workflow only triggers on `**.go`, `cmd/**` and `pkg/**`. Adding `go.mod` and `go.sum` there would let us require the tests as well, but that is a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments.
  * Refined automatic dependency-update merging to apply only to eligible pull requests targeting the main branch and passing required quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->