### PR TITLE
style(scripts): apply the repo's shell rules to init.sh and release.sh

### DIFF
--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -16,15 +16,21 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 log_info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
+    local msg="$1"
+    echo -e "${BLUE}[INFO]${NC} $msg"
+    return 0
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
+    local msg="$1"
+    echo -e "${GREEN}[SUCCESS]${NC} $msg"
+    return 0
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${NC} $1"
+    local msg="$1"
+    echo -e "${YELLOW}[WARNING]${NC} $msg"
+    return 0
 }
 
 # Check if git-cliff is installed
@@ -67,7 +73,7 @@ if git cliff --bump --output CHANGELOG.md; then
     # Extract the new version from the generated changelog
     next_version=$(head -10 CHANGELOG.md | grep -oE '\[([0-9]+\.[0-9]+\.[0-9]+)\]' | head -1 | tr -d '[]')
 
-    if [ -n "$next_version" ]; then
+    if [[ -n "$next_version" ]]; then
         next_version="v${next_version}"
         log_info "Next version will be: $next_version"
 

--- a/scripts/vm/init.sh
+++ b/scripts/vm/init.sh
@@ -17,7 +17,7 @@ VM_NAME="dev"
 APP_DIR="/srv/app"
 
 # Check if we're running in a devcontainer
-if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ] || [ -f "/.dockerenv" ]; then
+if [[ -n "${REMOTE_CONTAINERS}" ]] || [[ -n "${CODESPACES}" ]] || [[ -f "/.dockerenv" ]]; then
     echo "--- Detected devcontainer environment ---"
     DEVCONTAINER_MODE=true
 else
@@ -25,7 +25,7 @@ else
     DEVCONTAINER_MODE=false
 fi
 
-if [ "$DEVCONTAINER_MODE" = true ]; then
+if [[ "$DEVCONTAINER_MODE" == true ]]; then
     echo "--- Setting up devcontainer environment ---"
 
     # Install additional tools if needed


### PR DESCRIPTION
Both files were moved by git mv in the scripts/ regroup without being rewritten, so they kept the single-bracket tests and bare positional parameters that the rest of scripts/ no longer has. Default shellcheck does
not flag either -- SC2292 is opt-in -- but SonarCloud rates them MAJOR, and
with the security findings gone they were all that was left on main.

Explicit returns added to the three log helpers as well: the lines change
here, so S7682 would re-evaluate them as new code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of release and development environment setup checks.
  * Clarified command success handling and environment detection without changing setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->