### PR TITLE
ci: move workflows to Node 24 actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,30 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
+  # Maintain dependencies for GitHub Actions.
+  #
+  # `directory` must be "/" here: the docs say dependabot searches
+  # `.github/workflows` and a root `action.yml` relative to it, so the
+  # previous "/.github" was not the documented form. Whatever it did, this
+  # block's settings were not being honoured -- the only actions bumps that
+  # ever arrived were `chore(deps)` in an auto-named `github_actions` group,
+  # not `ci(deps)` as configured. Monthly on top of that let three major
+  # versions of actions/checkout pile up unnoticed.
   - package-ecosystem: "github-actions"
-    directory: "/.github"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
     labels:
       - "github-actions"
+    # Same prefix as gomod below so both land in the changelog's Dependencies
+    # section; cliff.toml matches on `^deps`.
     commit-message:
-      prefix: "ci"
+      prefix: "deps"
       include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   # Maintain dependencies for Golang
   - package-ecosystem: "gomod"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,8 +17,11 @@ on:
       - 'cmd/**'
       - 'pkg/**'
 
-env:
-  go-version: 1.26
+# No `go-version` here on purpose: setup-go reads go.mod instead. From v6 the
+# action sets GOTOOLCHAIN=local, so a `go-version` that resolves lower than
+# go.mod's `go` directive no longer silently downloads the newer toolchain --
+# it fails with `go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)`.
+# Reading go.mod keeps the two from drifting apart.
 
 # No workflow-level permissions: each job asks for what it needs, so a job that
 # only reads the checkout cannot write to the repo. `actions: write` and
@@ -32,7 +35,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Find Test Dirs
@@ -58,13 +61,13 @@ jobs:
       matrix:
         dir: ${{fromJson(needs.find-test-dirs.outputs.dirs)}}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: "./go.mod"
       - name: Test
         env:
@@ -82,20 +85,21 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # default fetch-depth is insufficent to find previous coverage notes
           fetch-depth: 10
           # Deliberately NOT persist-credentials: false, unlike every other
           # checkout here. go-coverage-action pushes refs/notes/gocoverage using
-          # the credentials checkout leaves in .git/config; dropping them breaks
-          # it with `git push origin refs/notes/gocoverage` exit code 128.
-          # Suppressed for this one step in .github/zizmor.yml.
-          persist-credentials: true
+          # the credentials checkout leaves behind; dropping them breaks it with
+          # `git push origin refs/notes/gocoverage` exit code 128. Since
+          # checkout v6 those credentials live in a file under $RUNNER_TEMP
+          # rather than in .git/config, which git picks up transparently.
+          persist-credentials: true # zizmor: ignore[artipacked]
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: "./go.mod"
       - name: Go Coverage Report
         id: coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,14 +80,18 @@ jobs:
             arch: amd64
             ext: ".exe"
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26'
+          # go.mod rather than a literal version: setup-go v6+ sets
+          # GOTOOLCHAIN=local, so a pinned `go-version` that resolves below
+          # go.mod's `go` directive fails the build instead of fetching the
+          # newer toolchain.
+          go-version-file: go.mod
           # Cache disabled: this workflow publishes release binaries, so a
           # poisoned cache entry written by a lower-privileged run could end up
           # compiled into them. Costs a cold module download per matrix leg.
@@ -119,7 +123,7 @@ jobs:
           ls -la kc.*
 
       - name: Upload archive artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kc-${{ matrix.platform }}-${{ matrix.arch }}
           path: kc.${{ matrix.platform }}.${{ matrix.arch }}.*
@@ -132,15 +136,15 @@ jobs:
       contents: read
       packages: write   # pushes the image to ghcr.io
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -170,7 +174,7 @@ jobs:
           echo "Generated tags: ${TAGS}"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -189,14 +193,18 @@ jobs:
     permissions:
       contents: write   # creates the GitHub release
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # Download all binary artifacts
+      # Download the binary artifacts. `pattern` matters: this used to take
+      # every artifact in the run, and build-push-action v6+ uploads a build
+      # record of its own, so an unrelated .dockerbuild artifact would land in
+      # ./artifacts too.
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: kc-*
           path: ./artifacts
 
       # Prepare release files
@@ -234,7 +242,7 @@ jobs:
 
       # Create GitHub Release
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ needs.check-tag.outputs.version }}
           name: Release ${{ needs.check-tag.outputs.version }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,14 +25,18 @@ jobs:
       contents: read
       security-events: write   # uploads trivy-results.sarif to code scanning
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26'
+          # go.mod rather than a literal version: setup-go v6+ sets
+          # GOTOOLCHAIN=local, so a pinned `go-version` that resolves below
+          # go.mod's `go` directive fails the build instead of fetching the
+          # newer toolchain.
+          go-version-file: go.mod
           # Cache disabled: this workflow builds and publishes a release image, so
           # a poisoned cache entry written by a lower-privileged run would end up
           # inside a published artifact. Costs a cold module download per release.
@@ -61,11 +65,11 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Build image locally first for security scanning
       - name: Build Docker image for scanning
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64  # Single platform for scanning

--- a/cliff.toml
+++ b/cliff.toml
@@ -55,23 +55,32 @@ commit_preprocessors = [
   #{ pattern = '.*', replace_command = 'typos --write-changes -' },
 ]
 # regex for parsing and grouping commits
+# The `<!-- NN -->` prefix only orders the sections -- the body template pipes the
+# group through `striptags`, so it never reaches CHANGELOG.md. Indices are
+# zero-padded because git-cliff sorts these as strings: with single digits,
+# adding a tenth group would sort `<!-- 10 -->` between 1 and 2.
 commit_parsers = [
-  { message = "^feat|^:sparkles:", group = "<!-- 0 -->🚀 Features" },
-  { message = "^fix|^:pencil2:|^:rotating_light:", group = "<!-- 1 -->🐛 Bug/Lint Fixes" },
-  { message = "^doc|^:memo:|^:page_facing_up:", group = "<!-- 3 -->📚 Documentation" },
-  { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
-  { message = "^refactor|^:recycle:|^:truck:", group = "<!-- 2 -->🚜 Refactor" },
-  { message = "^style|^:art:", group = "<!-- 5 -->🎨 Styling" },
-  { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+  { message = "^feat|^:sparkles:", group = "<!-- 00 -->🚀 Features" },
+  { message = "^fix|^:pencil2:|^:rotating_light:", group = "<!-- 01 -->🐛 Bug/Lint Fixes" },
+  { message = "^doc|^:memo:|^:page_facing_up:", group = "<!-- 03 -->📚 Documentation" },
+  { message = "^perf", group = "<!-- 04 -->⚡ Performance" },
+  { message = "^refactor|^:recycle:|^:truck:", group = "<!-- 02 -->🚜 Refactor" },
+  { message = "^style|^:art:", group = "<!-- 05 -->🎨 Styling" },
+  { message = "^test", group = "<!-- 06 -->🧪 Testing" },
   { message = "^chore\\(release\\): prepare for", skip = true },
   { message = "^chore\\(deps.*\\)", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },
-  { message = "^dep:", skip = true },
+  # dependabot is configured with `prefix: "deps"`, so its commits arrive as
+  # `deps(deps): bump ...`. The rule here used to be `^dep:`, which matches
+  # nothing at all -- there is no `dep` type and `deps:` has an `s` before the
+  # colon -- so those commits fell through to an unnamed `Deps` section. Must
+  # stay above `^chore|^ci`: the first matching parser wins.
+  { message = "^deps", group = "<!-- 07 -->📦 Dependencies" },
   { message = "^Merge", skip = true },
-  { message = "^chore|^ci|^:rocket:|^:construction:|^:bookmark:", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
-  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
-  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+  { message = "^chore|^ci|^:rocket:|^:construction:|^:bookmark:", group = "<!-- 08 -->⚙️ Miscellaneous Tasks" },
+  { body = ".*security", group = "<!-- 09 -->🛡️ Security" },
+  { message = "^revert", group = "<!-- 10 -->◀️ Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false


### PR DESCRIPTION
Every action in the release path was still on the Node 20 runtime, which the
runner now warns about on every job. Bumped the eight affected pins to their
current majors; github/codeql-action was already current.

Two of those majors change behaviour rather than just the runtime:

- setup-go v6+ sets GOTOOLCHAIN=local, so a `go-version` resolving below
  go.mod's `go` directive fails the build instead of downloading the newer
  toolchain. All three call sites now use go-version-file: go.mod.
- build-push-action v6+ uploads a build record artifact, which
  download-artifact would have swept into ./artifacts next to the release
  binaries. Restricted it to `pattern: kc-*`.

checkout v6 also moved persisted credentials out of .git/config into
$RUNNER_TEMP. Git reads them transparently, so the coverage job's git-notes
push is unaffected, but the comment describing it was stale -- and it pointed
at a .github/zizmor.yml that was never created. Replaced with an inline
zizmor ignore.

gwatts/go-coverage-action stays on Node 20: v2.0.0 is its latest release and
the repository has had no commits since 2024-03-24.

Also fixed the changelog's dependency section. `^dep:` could never match
anything -- dependabot emits `deps(deps):` -- so those commits fell through to
a bare `Deps` heading. They now group under 'Dependencies', and the sort
indices are zero-padded so a tenth group cannot sort between 1 and 2.
dependabot.yml gets the documented `directory: /` for github-actions, a weekly
schedule, and the same `deps` prefix.
